### PR TITLE
fix: govet error

### DIFF
--- a/client/etcd_discovery.go
+++ b/client/etcd_discovery.go
@@ -252,8 +252,6 @@ rewatch:
 				d.mu.Unlock()
 			}
 		}
-
-		log.Warn("chan is closed and will rewatch")
 	}
 }
 


### PR DESCRIPTION
ref https://travis-ci.org/github/rpcxio/rpcx-etcd/jobs/770878238#L811

这个日志的内容我感觉很疑惑，"chan is closed and will rewatch"

看内层 for 的两个 case ，https://github.com/rpcxio/rpcx-etcd/blob/ef67ef8fc51b7fad0fb7b7cb63cddafd8a7d17e0/client/etcd_discovery.go#L195-L198，无论谁被 close，整个 watch() 函数就退出了，为什么会 "rewatch" ？