### PR TITLE
fix etcd3 service discovery

### DIFF
--- a/client/etcdv3_discovery.go
+++ b/client/etcdv3_discovery.go
@@ -78,7 +78,7 @@ func NewEtcdV3DiscoveryStore(basePath string, kv store.Store) (client.ServiceDis
 				}
 			}
 		}
-		if p.Key == prefix[:len(prefix)-1] {
+		if p.Key == prefix[:len(prefix)-1] || !strings.HasPrefix(p.Key, prefix) {
 			continue
 		}
 		k := strings.TrimPrefix(p.Key, prefix)


### PR DESCRIPTION
fix  bug when two services  has the same prefix  that cause the client find the wrong service