### PR TITLE
key not exists is not an fatal error in watchTree

### DIFF
--- a/store/etcdv3/etcdv3.go
+++ b/store/etcdv3/etcdv3.go
@@ -291,7 +291,7 @@ func (s *EtcdV3) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*
 		defer close(watchCh)
 
 		list, err := s.List(directory)
-		if err != nil {
+		if err != nil && err != store.ErrKeyNotFound {
 			return
 		}
 
@@ -304,7 +304,7 @@ func (s *EtcdV3) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*
 				return
 			case <-rch:
 				list, err := s.List(directory)
-				if err != nil {
+				if err != nil && err != store.ErrKeyNotFound {
 					return
 				}
 				watchCh <- list


### PR DESCRIPTION
key not exists is not an fatal error in watchTree
compatible behavior with https://github.com/smallnest/libkv-etcdv3-store/blob/master/etcdv3.go
otherwise it will cause service start dependency problem