### PR TITLE
give a choice to set etcd AutoSyncInterval

### DIFF
--- a/store/etcdv3/etcdv3.go
+++ b/store/etcdv3/etcdv3.go
@@ -16,6 +16,10 @@ import (
 
 const defaultTTL = 30
 
+// EtcdConfigAutoSyncInterval give a choice to those etcd cluster could not auto sync
+// such I deploy clusters in docker they will dial tcp: lookup etcd1: Try again, can just set this to zero
+var EtcdConfigAutoSyncInterval = time.Minute * 5
+
 // EtcdV3 is the receiver type for the Store interface
 type EtcdV3 struct {
 	timeout        time.Duration
@@ -57,7 +61,7 @@ func New(addrs []string, options *store.Config) (store.Store, error) {
 		cfg.Username = options.Username
 		cfg.Password = options.Password
 
-		cfg.AutoSyncInterval = 5 * time.Minute
+		cfg.AutoSyncInterval = EtcdConfigAutoSyncInterval
 	}
 	if s.timeout == 0 {
 		s.timeout = 10 * time.Second


### PR DESCRIPTION
 I deploy etcd clusters in docker they will err:

```
 {"level":"warn","ts":"2021-09-07T15:28:43.618+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc0001a9500/#initially=[172.17.0.1:12378;172.17.0.1:22378;172.17.0.1:32378]","attempt":0,"error":"rpc error: code = DeadlineExceeded desc = latest balancer error: last connection error: connection error: desc = \"transport: Error while dialing dial tcp: lookup naetcd2: Try again\""}
```

you know, give a choice to set AutoSyncInterval = 0 when not hope sync.