### PR TITLE
修复v3重连watch问题

### DIFF
--- a/client/etcdv3_discovery.go
+++ b/client/etcdv3_discovery.go
@@ -221,7 +221,7 @@ rewatch:
 				return
 			case ps, ok := <-c: // closed, reconnect (rewatch)
 				if !ok {
-					break rewatch
+					goto rewatch
 				}
 				var pairs []*client.KVPair // latest servers
 				if ps == nil && !d.AllowKeyNotFound {


### PR DESCRIPTION
具体可见https://github.com/rpcxio/rpcx-etcd/pull/29
v3文件漏改了