### PR TITLE
fix: RegisterFunctionName Cause duplicate registration listening

### DIFF
--- a/serverplugin/etcd.go
+++ b/serverplugin/etcd.go
@@ -204,7 +204,15 @@ func (p *EtcdRegisterPlugin) Register(name string, rcvr interface{}, metadata st
 		log.Errorf("cannot create etcd path %s: %v", nodePath, err)
 		return err
 	}
-	p.Services = append(p.Services, name)
+
+	services := make(map[string]struct{})
+	for _, v := range p.Services {
+		services[v] = struct{}{}
+	}
+
+	if _, ok := services[name]; !ok {
+		p.Services = append(p.Services, name)
+	}
 
 	p.metasLock.Lock()
 	if p.metas == nil {


### PR DESCRIPTION
使用 `RegisterFunctionName` 注册N个函数，就会产生 N个etcd 监听。 实际都是监听都是同一个 `service`。